### PR TITLE
upgrade for streams2 levelup readstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var ReadStream = require("read-stream")
     , WriteStream = require("write-stream")
-    , wrap = require("streams2")
 
 module.exports = query
 
@@ -12,7 +11,7 @@ function query(db, options) {
         , start = options.start
         , end = options.end
         , writer = WriteStream(write, loaded)
-        , reader = wrap(db.readStream(options))
+        , reader = db.readStream(options)
 
     reader.pipe(writer)
 


### PR DESCRIPTION
Looks like this lib needs a bit of love .. can't install devdeps because levelidb uses an old version of leveldb that doesn't compile on the mac I'm on right now and there are no tests anyway.

I'm using this lib now but have had to remove the `'streams2'` wrapper to make it work properly (perhaps `'streams2'` should detect if it's a streams2 impl or not before wrapping?)
